### PR TITLE
Functionally multithreaded.

### DIFF
--- a/KmerCounting.xcodeproj/project.pbxproj
+++ b/KmerCounting.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		B78D7D341D303A0600B4A685 /* Helper.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B78D7D321D303A0600B4A685 /* Helper.cpp */; };
 		B79019061D00CE41005B32B8 /* main.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B79019051D00CE41005B32B8 /* main.cpp */; };
 		B792F2EC1D4D3761000CE8F1 /* Usage.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B792F2EA1D4D3761000CE8F1 /* Usage.cpp */; };
+		B7B4F9771D5AC5D900D1C92D /* MutedQueue.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B7B4F9751D5AC5D900D1C92D /* MutedQueue.cpp */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -37,6 +38,8 @@
 		B79019051D00CE41005B32B8 /* main.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = main.cpp; sourceTree = "<group>"; };
 		B792F2EA1D4D3761000CE8F1 /* Usage.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Usage.cpp; sourceTree = "<group>"; };
 		B792F2EB1D4D3761000CE8F1 /* Usage.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = Usage.hpp; sourceTree = "<group>"; };
+		B7B4F9751D5AC5D900D1C92D /* MutedQueue.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MutedQueue.cpp; sourceTree = "<group>"; };
+		B7B4F9761D5AC5D900D1C92D /* MutedQueue.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = MutedQueue.hpp; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -78,6 +81,8 @@
 				B78D7D331D303A0600B4A685 /* Helper.hpp */,
 				B792F2EA1D4D3761000CE8F1 /* Usage.cpp */,
 				B792F2EB1D4D3761000CE8F1 /* Usage.hpp */,
+				B7B4F9751D5AC5D900D1C92D /* MutedQueue.cpp */,
+				B7B4F9761D5AC5D900D1C92D /* MutedQueue.hpp */,
 			);
 			path = KmerCounting;
 			sourceTree = "<group>";
@@ -143,6 +148,7 @@
 				B79019061D00CE41005B32B8 /* main.cpp in Sources */,
 				B78D7D2E1D05DF1500B4A685 /* Occ.cpp in Sources */,
 				B78D7D341D303A0600B4A685 /* Helper.cpp in Sources */,
+				B7B4F9771D5AC5D900D1C92D /* MutedQueue.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/KmerCounting.xcodeproj/xcuserdata/gurudev.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/KmerCounting.xcodeproj/xcuserdata/gurudev.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -14,6 +14,16 @@
 			<key>orderHint</key>
 			<integer>0</integer>
 		</dict>
+		<key>kmerTest.xcscheme</key>
+		<dict>
+			<key>orderHint</key>
+			<integer>2</integer>
+		</dict>
+		<key>smallKmerCounting.xcscheme</key>
+		<dict>
+			<key>orderHint</key>
+			<integer>1</integer>
+		</dict>
 	</dict>
 	<key>SuppressBuildableAutocreation</key>
 	<dict>

--- a/KmerCounting/Helper.cpp
+++ b/KmerCounting/Helper.cpp
@@ -10,9 +10,6 @@
 #include <string>
 #include <iostream>
 
-void processNode() {
-    //count the number of children
-}
 
 
 std::vector<long long> getIntervalBasedOn(std::vector<long long> interval, char character, Occ & occ) {

--- a/KmerCounting/Helper.hpp
+++ b/KmerCounting/Helper.hpp
@@ -14,7 +14,6 @@
 #include "Occ.hpp"
 
 
-void processNode();
 std::vector<long long> getIntervalBasedOn(std::vector<long long> interval, char character, Occ & occ);
 std::vector<long long> getReverseIntervalBasedOn(std::vector<long long> interval, std::vector<long long> reverseInterval, char character, string & reverseBWT, Occ & occ);
 string prepend(char charToPrepend, string pattern);

--- a/KmerCounting/MutedQueue.cpp
+++ b/KmerCounting/MutedQueue.cpp
@@ -1,0 +1,26 @@
+//
+//  MutedQueue.cpp
+//  KmerCounting
+//
+//  Created by Rishil on 8/9/16.
+//  Copyright © 2016 Rishil Mehta. All rights reserved.
+//
+
+#include "MutedQueue.hpp"
+#include <mutex>
+
+void MutedQueue::loadQueue(std::queue<Node> initialQueue) {
+    MutedQueue::nodeQueue = initialQueue;
+}
+
+bool MutedQueue::loadIntoInternalNode(Node &internalNode) {
+    
+    std::lock_guard<std::mutex> guard(MutedQueue::queueMutex);
+    if(!MutedQueue::nodeQueue.empty()) {
+        internalNode = MutedQueue::nodeQueue.front();
+        MutedQueue::nodeQueue.pop();
+        return true;
+    }
+    
+    return false;
+}

--- a/KmerCounting/MutedQueue.hpp
+++ b/KmerCounting/MutedQueue.hpp
@@ -1,0 +1,32 @@
+//
+//  MutedQueue.hpp
+//  KmerCounting
+//
+//  Created by Rishil on 8/9/16.
+//  Copyright © 2016 Rishil Mehta. All rights reserved.
+//
+
+#ifndef MutedQueue_hpp
+#define MutedQueue_hpp
+
+#include <stdio.h>
+#include <queue>
+#include "Node.hpp"
+#include <mutex>
+
+//Implements a thread-safe version of nodeQueue for this program
+
+class MutedQueue {
+    
+public:
+    void loadQueue(std::queue<Node> initialQueue);
+    bool loadIntoInternalNode(Node &internalNode);
+
+
+private:
+    std::queue<Node> nodeQueue;
+    std::mutex queueMutex;
+    
+};
+
+#endif /* MutedQueue_hpp */

--- a/KmerCounting/Node.cpp
+++ b/KmerCounting/Node.cpp
@@ -10,6 +10,8 @@
 #include <vector>
 #include <string>
 
+
+
 int Node::getNumberOfChildren(std::string & reverseBWT, long long $_pos) {
     //NOTE: I opted against using reverse Occ to do this computation. I think this may increase the computational time a little, but halves the space requirement, and lowers the complexity of the code.
     
@@ -26,12 +28,16 @@ int Node::getNumberOfChildren(std::string & reverseBWT, long long $_pos) {
     for (size_t i = start; i <= end; i++) {
         char rBWTChar = reverseBWT[i];
         switch(rBWTChar) {
-            case 'A' : characters[0] = 1;
+            case 'a':
+            case 'A': characters[0] = 1;
                 break;
+            case 'c':
             case 'C' : characters[1] = 1;
                 break;
+            case 'g':
             case 'G' : characters[2] = 1;
                 break;
+            case 't':
             case 'T' : characters[3] = 1;
                 break;
             case 'N' : //TODO: add support for N

--- a/KmerCounting/Node.hpp
+++ b/KmerCounting/Node.hpp
@@ -13,6 +13,7 @@
 #include <iostream>
 #include <vector>
 #include <string>
+#include <stack>
 
 struct Node {
     std::vector<long long> interval;
@@ -22,6 +23,7 @@ struct Node {
     int numberOfChildren;
     int getNumberOfChildren(std::string & reverseBWT, long long $_pos);
     bool isRightMaximal();
+    void processNode(std::vector<long long> & dOcc, std::stack<Node> & nodeStack);
 };
 
 #endif /* Node_hpp */


### PR DESCRIPTION
Against a random 1.8GBP sequence. It took:

4m52s to complete (of which approx 1m23s was just building the Occ table), using 57GB of RAM.

In comparison, multi-threaded Jellyfish took:
4m0s to complete (of which approx 1m13s was just using "stats" to ask for the result), using 11GB of RAM.
